### PR TITLE
fix: Redis Pub/Sub 연결을 Standalone으로 분리

### DIFF
--- a/src/main/java/com/example/planmate/common/config/PlanMateRedisConfig.java
+++ b/src/main/java/com/example/planmate/common/config/PlanMateRedisConfig.java
@@ -3,11 +3,15 @@ package com.example.planmate.common.config;
 import java.util.UUID;
 
 import com.example.planmate.common.oauth.dto.OAuthSignupCache;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -54,6 +58,22 @@ public class PlanMateRedisConfig {
             }
             return factory;
         }
+    }
+
+    @Bean(name = "pubSubRedisConnectionFactory")
+    public RedisConnectionFactory pubSubRedisConnectionFactory() {
+        RedisStandaloneConfiguration standaloneConfig = new RedisStandaloneConfiguration(host, port);
+        if (password != null && !password.isEmpty()) {
+            standaloneConfig.setPassword(RedisPassword.of(password));
+        }
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(standaloneConfig);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    @Bean(name = "sseStringRedisTemplate")
+    public StringRedisTemplate sseStringRedisTemplate(@Qualifier("pubSubRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
     }
 
     @Bean(name = "refreshTokenRedis")

--- a/src/main/java/com/example/planmate/common/config/SseRedisConfig.java
+++ b/src/main/java/com/example/planmate/common/config/SseRedisConfig.java
@@ -27,7 +27,7 @@ public class SseRedisConfig {
 
     @Bean
     public RedisMessageListenerContainer sseRedisListenerContainer(
-            RedisConnectionFactory connectionFactory,
+            @org.springframework.beans.factory.annotation.Qualifier("pubSubRedisConnectionFactory") RedisConnectionFactory connectionFactory,
             SseRedisSubscriber subscriber) {
 
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();

--- a/src/main/java/com/example/planmate/common/sse/SseEmitterService.java
+++ b/src/main/java/com/example/planmate/common/sse/SseEmitterService.java
@@ -37,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class SseEmitterService {
 
     private static final long SSE_TIMEOUT = 30 * 60 * 1000L; // 30분
@@ -45,8 +44,14 @@ public class SseEmitterService {
     // Multiple emitters per user to support multiple tabs / simultaneous connections
     private final ConcurrentHashMap<UUID, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final StringRedisTemplate sseStringRedisTemplate;
     private final ObjectMapper objectMapper;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public SseEmitterService(@org.springframework.beans.factory.annotation.Qualifier("sseStringRedisTemplate") StringRedisTemplate sseStringRedisTemplate, ObjectMapper objectMapper) {
+        this.sseStringRedisTemplate = sseStringRedisTemplate;
+        this.objectMapper = objectMapper;
+    }
 
     public SseEmitter subscribe(UUID userId) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
@@ -89,7 +94,7 @@ public class SseEmitterService {
         SseNotificationMessage message = new SseNotificationMessage(userId.toString(), eventName, data);
         try {
             String json = objectMapper.writeValueAsString(message);
-            stringRedisTemplate.convertAndSend(SseRedisConfig.SSE_CHANNEL, json);
+            sseStringRedisTemplate.convertAndSend(SseRedisConfig.SSE_CHANNEL, json);
         } catch (JsonProcessingException e) {
             log.warn("SSE 알림 직렬화 실패 (userId: {}, event: {}): {}", userId, eventName, e.getMessage());
             deliverToLocalEmitters(userId, eventName, data);


### PR DESCRIPTION
Master/Replica 구성에서는 Pub/Sub 구독이 지원되지 않아
Pub/Sub 전용 RedisConnectionFactory를 Standalone으로 생성하고 SSE 및 SharedSync 리스너가 이를 사용하도록 수정