### PR TITLE
fix(k8s): sentinel 노드를 개별 파드 주소로 나열

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -11,8 +11,11 @@ data:
   # Sentinel 기반 HA: nodes가 설정되면 Lettuce가 sentinel에게 현재 master를 물어
   # 직접 연결한다(고정 master Service에 의존하지 않으므로 노드 장애 시 자동 failover를 따라감).
   # sentinel.password는 deployment에서 secret(REDIS_PASSWORD)로 주입.
+  # nodes는 sentinel 파드를 개별 주소로 나열한다. ClusterIP Service 하나만 주면
+  # Lettuce 입장에서 sentinel이 1개뿐이라, 그 요청이 고장난 sentinel에 걸렸을 때
+  # 물러설 곳이 없다(master 조회 실패 -> 쓰기가 replica로 흘러 READONLY 발생).
   SPRING_DATA_REDIS_SENTINEL_MASTER: "myMaster"
-  SPRING_DATA_REDIS_SENTINEL_NODES: "planmate-redis-sentinel-sentinel:26379"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "planmate-redis-sentinel-sentinel-0.planmate-redis-sentinel-sentinel-headless.default.svc.cluster.local:26379,planmate-redis-sentinel-sentinel-1.planmate-redis-sentinel-sentinel-headless.default.svc.cluster.local:26379,planmate-redis-sentinel-sentinel-2.planmate-redis-sentinel-sentinel-headless.default.svc.cluster.local:26379"
   DB_URL: "jdbc:p6spy:postgresql://planmate-db-rw:5432/planmate"
   STORAGE_TYPE: "minio"
   MINIO_ENDPOINT: "http://myminio-hl.default.svc.cluster.local:9000"


### PR DESCRIPTION
## 문제

운영 백엔드에서 아래 오류가 간헐적으로 발생하고 있었습니다.

```
io.lettuce.core.RedisReadOnlyException: READONLY You can't write against a read only replica
  at com.sharedsync.shared.storage.RedisPresenceStorage.refreshSession(RedisPresenceStorage.java:103)
```

Redis 연결 실패가 아니라, **연결은 되는데 쓰기가 replica로 가는** 문제였습니다.

## 원인

`SPRING_DATA_REDIS_SENTINEL_NODES` 가 ClusterIP Service 하나만 가리키고 있었습니다.

```yaml
SPRING_DATA_REDIS_SENTINEL_NODES: "planmate-redis-sentinel-sentinel:26379"
```

이 Service는 sentinel 3대를 라운드로빈하지만, Lettuce 입장에서는 **sentinel이 1개**로 보입니다. 그래서 master 조회 요청이 고장난 sentinel에 걸리면 물러설 곳이 없고, `ReadFrom.REPLICA_PREFERRED` 상태에서 쓰기가 replica로 흘러 READONLY가 납니다.

실제로 `planmate-redis-sentinel-sentinel-0` 이 2026-07-14 08:10 부터 4일간 monitor 설정을 잃은 상태였습니다. redis-operator 가 reconcile 마다 `SENTINEL REMOVE` → `SENTINEL MONITOR` 로 재등록하는데, 그 사이에서 실패하면 master 없는 상태로 남고, 다음 reconcile 은 REMOVE 가 `ERR No such master with that name` 로 실패하면서 재등록 단계에 도달하지 못하는 교착에 빠집니다.

```
14 Jul 08:10:48  -monitor master myMaster 10.42.1.56 6379   ← 제거만 되고
18 Jul 05:07:48  +monitor master myMaster 10.42.0.82 6379   ← 수동 조치까지 4일 공백
```

sentinel-0 은 수동으로 `SENTINEL MONITOR` 를 재발급해 이미 복구했고, 그 직후 operator reconcile 도 정상 사이클을 회복했습니다. 이 PR 은 **같은 일이 재발해도 앱이 버티게** 만드는 변경입니다.

## 변경

headless Service 기반 파드별 DNS 3개를 나열합니다. 한 대가 고장나도 Lettuce 가 나머지 sentinel 에서 master 를 찾습니다. 파드 IP 가 바뀌어도 DNS 이름은 고정입니다.

`PlanMateRedisConfig.sentinelConfiguration()` 이 `,` 로 분리해 `lastIndexOf(':')` 로 host/port 를 나누므로 형식은 그대로 호환됩니다.

## 확인한 것

- 백엔드 파드에서 3개 DNS 모두 정상 해석 (`10.42.0.86` / `10.42.3.77` / `10.42.1.110`)
- YAML 파싱 및 host/port 분리 결과 검증
- sentinel 3대 모두 현재 `sentinel_masters:1`, `status=ok`

## 확인하지 못한 것

- Lettuce 가 master 를 못 준 sentinel 에서 다음 sentinel 로 넘어가는 동작은 라이브러리 표준 동작이지만, 이 환경에서 실측하지는 않았습니다. sentinel 1대의 monitor 를 일부러 제거해두고 쓰기가 계속되는지 보면 확인 가능합니다.

## 배포 시 주의

- ArgoCD 가 `main` 을 auto-sync 하므로 **머지 즉시 ConfigMap 이 반영**됩니다.
- ConfigMap 은 env 로 주입되어 hot-reload 가 되지 않으므로, 적용하려면 **백엔드 롤링 재시작이 필요**합니다.

## 남은 별개 이슈

- redis-operator 의 비원자적 재등록 교착 자체는 그대로입니다. 이 PR 은 그 영향을 앱이 흡수하게 할 뿐입니다.
- Redis 본체 2대 모두 `requirepass` 가 비어 있는데 sentinel.conf 와 앱 env 는 `redis1234` 를 갖고 있는 불일치가 있습니다. 현재 동작에는 지장 없지만 정리 대상입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)